### PR TITLE
fix: add Send bound to Streaming wrapper

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -193,7 +193,6 @@ impl<S: StreamingResponse> futures::Stream for ServiceStreamingResponse<S> {
     }
 }
 
-/// Wrapper around `ServiceStreamingResponse` to expose publicly.
 pub struct Streaming<R>(Box<dyn Unpin + Send + futures::Stream<Item = Result<R, ClientError>>>);
 
 impl<R> Streaming<R> {


### PR DESCRIPTION
useful for moving ownership to the spawn closure,

```
let mut response_stream = client.append_session(request).await?;

    let response_consumer = tokio::spawn(async move {
        while let Some(n) = response_stream.next().await {
            if let Err(e) = n {
                error!(?e, "receiver error")
            }
        }
    });
```