### PR TITLE
fix: Use `if_exists` for delete basin/stream

### DIFF
--- a/src/service/account.rs
+++ b/src/service/account.rs
@@ -111,7 +111,12 @@ impl ServiceRequest for DeleteBasinServiceRequest {
         &mut self,
         req: tonic::Request<Self::ApiRequest>,
     ) -> Result<tonic::Response<Self::ApiResponse>, tonic::Status> {
-        self.client.delete_basin(req).await
+        match self.client.delete_basin(req).await {
+            Err(status) if self.req.if_exists && status.code() == tonic::Code::NotFound => {
+                Ok(tonic::Response::new(api::DeleteBasinResponse {}))
+            }
+            other => other,
+        }
     }
 
     fn parse_response(

--- a/src/service/basin.rs
+++ b/src/service/basin.rs
@@ -154,7 +154,12 @@ impl ServiceRequest for DeleteStreamServiceRequest {
         &mut self,
         req: tonic::Request<Self::ApiRequest>,
     ) -> Result<tonic::Response<Self::ApiResponse>, tonic::Status> {
-        self.client.delete_stream(req).await
+        match self.client.delete_stream(req).await {
+            Err(status) if self.req.if_exists && status.code() == tonic::Code::NotFound => {
+                Ok(tonic::Response::new(api::DeleteStreamResponse {}))
+            }
+            other => other,
+        }
     }
 
     fn parse_response(

--- a/src/types.rs
+++ b/src/types.rs
@@ -606,6 +606,7 @@ impl TryFrom<api::ListBasinsResponse> for ListBasinsResponse {
 #[derive(Debug, Clone)]
 pub struct DeleteBasinRequest {
     pub basin: BasinName,
+    /// Delete basin if it exists else do nothing.
     pub if_exists: bool,
 }
 
@@ -634,6 +635,7 @@ impl From<DeleteBasinRequest> for api::DeleteBasinRequest {
 #[derive(Debug, Clone)]
 pub struct DeleteStreamRequest {
     pub stream: String,
+    /// Delete stream if it exists else do nothing.
     pub if_exists: bool,
 }
 


### PR DESCRIPTION
This probably got removed when we shifted to using simply `Status` for errors which removed `parse_status`.

Resolves: #83