### PR TITLE
fix: append_session inner loop while condition

### DIFF
--- a/src/append_session.rs
+++ b/src/append_session.rs
@@ -225,7 +225,7 @@ where
     tokio::pin!(timer);
     let mut input_terminated = false;
 
-    while !input_terminated {
+    while !(input_terminated && inflight.is_empty()) {
         tokio::select! {
             (event_ord, _deadline) = &mut timer,
                 if timer.is_armed()


### PR DESCRIPTION
Resolves https://github.com/s2-streamstore/s2-sdk-rust/issues/90

Reproduces with this:
```bash
rand_key=$(head -c 8 /dev/urandom | base64) && echo $rand_key
count=1; while [ "$count" -le 1000 ] ; do echo "$count $rand_key"; ((count++)); done \
        | s2 stream my-basin4 my-stream1 append
```
which returns:
```console
sbFi2e7W3iw=
Error:
  × Main thread panicked.
  ├─▶ at /Users/sb/.cargo/git/checkouts/s2-sdk-rust-6c37de187e75d8b0/d40de3d/src/append_session.rs:293:5
  ╰─▶ assertion `left == right` failed
        left: 1
       right: 0
  help: set the `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

When version of SDK used by CLI is updated, appends work as expected.