### PR TITLE
chore: Remove `GH_TOKEN` use to clone submodule in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
         uses: actions/checkout@v4
         with:
             submodules: true
-            token: ${{ secrets.GH_TOKEN }}
       - name: install rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -52,7 +51,6 @@ jobs:
         uses: actions/checkout@v4
         with:
             submodules: true
-            token: ${{ secrets.GH_TOKEN }}
       - name: install rust
         uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
Since it's a public repository now.