### PR TITLE
docs: Update README API link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 </div>
 
 The Rust SDK provides ergonomic wrappers and utilities to interact with the
-[S2 API](https://buf.build/streamstore/s2/docs/main:s2.v1alpha).
+[S2 API](https://s2.dev/docs/interface/grpc-api).
 
 ## Getting started
 


### PR DESCRIPTION
Link `s2.dev/docs` directly.