### PR TITLE
Retry `CANCELLED` gRPC status code

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -99,7 +99,10 @@ pub trait ServiceRequest: std::fmt::Debug {
         if let ClientError::Service(status) = err {
             matches!(
                 status.code(),
-                tonic::Code::Unavailable | tonic::Code::DeadlineExceeded | tonic::Code::Unknown
+                tonic::Code::Unavailable
+                    | tonic::Code::DeadlineExceeded
+                    | tonic::Code::Cancelled
+                    | tonic::Code::Unknown
             )
         } else {
             false

--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -228,7 +228,10 @@ impl ServiceRequest for AppendServiceRequest {
         if let ClientError::Service(status) = err {
             let retryable_error = matches!(
                 status.code(),
-                tonic::Code::Unavailable | tonic::Code::DeadlineExceeded | tonic::Code::Unknown
+                tonic::Code::Unavailable
+                    | tonic::Code::DeadlineExceeded
+                    | tonic::Code::Cancelled
+                    | tonic::Code::Unknown
             );
             let policy_compliant = match self.append_retry_policy {
                 AppendRetryPolicy::All => true,


### PR DESCRIPTION
This is what we get from tonic when the server closes the connection with an http2 `GOAWAY`, and the response was pending (reconnection happens on subsequent request)

```
Status { code: Cancelled, message: "operation was canceled", source: Some(tonic::transport::Error(Transport, hyper::Error(Canceled, "connection closed"))) }
```