### PR TITLE
chore: Upgrade proto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "streamstore"
 description = "Rust SDK for S2"
 version = "0.8.2"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 keywords = ["wal", "grpc", "s2", "log", "stream"]
 repository = "https://github.com/s2-streamstore/s2-sdk-rust"

--- a/examples/create_basin.rs
+++ b/examples/create_basin.rs
@@ -20,6 +20,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let basin_config = BasinConfig {
         default_stream_config: Some(default_stream_config),
+        create_stream_on_append: false,
     };
 
     let create_basin_request = CreateBasinRequest::new(basin.clone()).with_config(basin_config);

--- a/examples/reconfigure_basin.rs
+++ b/examples/reconfigure_basin.rs
@@ -15,6 +15,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         StreamConfig::new().with_storage_class(StorageClass::Standard);
     let basin_config_updates = BasinConfig {
         default_stream_config: Some(default_stream_config_updates),
+        create_stream_on_append: true,
     };
 
     let reconfigure_basin_request = ReconfigureBasinRequest::new(basin)

--- a/src/append_session.rs
+++ b/src/append_session.rs
@@ -7,7 +7,7 @@ use std::{
 
 use futures::StreamExt;
 use tokio::{
-    sync::{mpsc, mpsc::Permit, Mutex},
+    sync::{Mutex, mpsc, mpsc::Permit},
     time::Instant,
 };
 use tokio_muxt::{CoalesceMode, MuxTimer};
@@ -19,8 +19,8 @@ use tracing::debug;
 use crate::{
     client::{AppendRetryPolicy, ClientError, StreamClient},
     service::{
-        stream::{AppendSessionServiceRequest, AppendSessionStreamingResponse},
         ServiceStreamingResponse,
+        stream::{AppendSessionServiceRequest, AppendSessionStreamingResponse},
     },
     types,
     types::MeteredBytes,

--- a/src/client.rs
+++ b/src/client.rs
@@ -35,7 +35,7 @@ use std::{env::VarError, fmt::Display, str::FromStr, time::Duration};
 
 use backon::{BackoffBuilder, ConstantBuilder, Retryable};
 use futures::StreamExt;
-use http::{uri::Authority, HeaderValue};
+use http::{HeaderValue, uri::Authority};
 use hyper_util::client::legacy::connect::HttpConnector;
 use secrecy::SecretString;
 use sync_docs::sync_docs;
@@ -54,6 +54,7 @@ use crate::{
     },
     append_session,
     service::{
+        ServiceRequest, ServiceStreamingResponse, Streaming,
         account::{
             CreateBasinServiceRequest, DeleteBasinServiceRequest, GetBasinConfigServiceRequest,
             ListBasinsServiceRequest, ReconfigureBasinServiceRequest,
@@ -67,9 +68,8 @@ use crate::{
             AppendServiceRequest, CheckTailServiceRequest, ReadServiceRequest,
             ReadSessionServiceRequest, ReadSessionStreamingResponse,
         },
-        ServiceRequest, ServiceStreamingResponse, Streaming,
     },
-    types::{self, MeteredBytes, MIB_BYTES},
+    types::{self, MIB_BYTES, MeteredBytes},
 };
 
 const DEFAULT_CONNECTOR: Option<HttpConnector> = None;
@@ -817,7 +817,7 @@ impl ClientInner {
             .await
     }
 
-    pub(crate) fn backoff_builder(&self) -> impl BackoffBuilder {
+    pub(crate) fn backoff_builder(&self) -> impl BackoffBuilder + use<> {
         ConstantBuilder::default()
             .with_delay(self.config.retry_backoff_duration)
             .with_max_times(self.config.max_attempts)

--- a/src/service/account.rs
+++ b/src/service/account.rs
@@ -1,7 +1,7 @@
 use prost_types::method_options::IdempotencyLevel;
-use tonic::{transport::Channel, IntoRequest};
+use tonic::{IntoRequest, transport::Channel};
 
-use super::{add_s2_request_token_header, gen_s2_request_token, ServiceRequest};
+use super::{ServiceRequest, add_s2_request_token_header, gen_s2_request_token};
 use crate::{
     api::{self, account_service_client::AccountServiceClient},
     types,

--- a/src/service/basin.rs
+++ b/src/service/basin.rs
@@ -1,7 +1,7 @@
 use prost_types::method_options::IdempotencyLevel;
-use tonic::{transport::Channel, IntoRequest};
+use tonic::{IntoRequest, transport::Channel};
 
-use super::{add_s2_request_token_header, gen_s2_request_token, ServiceRequest};
+use super::{ServiceRequest, add_s2_request_token_header, gen_s2_request_token};
 use crate::{
     api::{self, basin_service_client::BasinServiceClient},
     types,

--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -1,5 +1,5 @@
 use prost_types::method_options::IdempotencyLevel;
-use tonic::{codec::CompressionEncoding, transport::Channel, IntoRequest};
+use tonic::{IntoRequest, codec::CompressionEncoding, transport::Channel};
 use tonic_side_effect::{FrameSignal, RequestFrameMonitor};
 
 use super::{
@@ -102,7 +102,7 @@ impl ServiceRequest for ReadServiceRequest {
         &self,
         resp: tonic::Response<Self::ApiResponse>,
     ) -> Result<Self::Response, types::ConvertError> {
-        resp.into_inner().try_into().map_err(Into::into)
+        resp.into_inner().try_into()
     }
 }
 
@@ -233,7 +233,7 @@ impl ServiceRequest for AppendServiceRequest {
         &self,
         resp: tonic::Response<Self::ApiResponse>,
     ) -> Result<Self::Response, types::ConvertError> {
-        resp.into_inner().try_into().map_err(Into::into)
+        resp.into_inner().try_into()
     }
 
     fn should_retry(&self, err: &ClientError) -> bool {

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,7 +3,7 @@
 use std::{ops::Deref, str::FromStr, sync::OnceLock, time::Duration};
 
 use bytes::Bytes;
-use rand::{distributions::Uniform, Rng};
+use rand::{Rng, distributions::Uniform};
 use regex::Regex;
 use sync_docs::sync_docs;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -89,7 +89,7 @@ impl FromStr for BasinScope {
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
             "unspecified" => Ok(Self::Unspecified),
-            "aws_us_east_1" => Ok(Self::AwsUsEast1),
+            "aws:us-east-1" => Ok(Self::AwsUsEast1),
             _ => Err("invalid basin scope value".into()),
         }
     }
@@ -1593,7 +1593,6 @@ impl TryFrom<api::ReadResponse> for ReadOutput {
 pub struct ReadSessionRequest {
     pub start_seq_num: u64,
     pub limit: ReadLimit,
-    pub heartbeats: bool,
 }
 
 impl ReadSessionRequest {
@@ -1610,16 +1609,10 @@ impl ReadSessionRequest {
         Self { limit, ..self }
     }
 
-    /// Overwrite heartbeats.
-    pub fn with_heartbeats(self, heartbeats: bool) -> Self {
-        Self { heartbeats, ..self }
-    }
-
     pub(crate) fn into_api_type(self, stream: impl Into<String>) -> api::ReadSessionRequest {
         let Self {
             start_seq_num,
             limit,
-            heartbeats,
         } = self;
         api::ReadSessionRequest {
             stream: stream.into(),
@@ -1628,7 +1621,7 @@ impl ReadSessionRequest {
                 count: limit.count,
                 bytes: limit.bytes,
             }),
-            heartbeats,
+            heartbeats: false,
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -59,11 +59,63 @@ macro_rules! metered_impl {
 }
 
 #[sync_docs]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BasinScope {
+    #[default]
+    Unspecified,
+    AwsUsEast1,
+}
+
+impl From<BasinScope> for api::BasinScope {
+    fn from(value: BasinScope) -> Self {
+        match value {
+            BasinScope::Unspecified => Self::Unspecified,
+            BasinScope::AwsUsEast1 => Self::AwsUsEast1,
+        }
+    }
+}
+
+impl From<api::BasinScope> for BasinScope {
+    fn from(value: api::BasinScope) -> Self {
+        match value {
+            api::BasinScope::Unspecified => Self::Unspecified,
+            api::BasinScope::AwsUsEast1 => Self::AwsUsEast1,
+        }
+    }
+}
+
+impl FromStr for BasinScope {
+    type Err = ConvertError;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "unspecified" => Ok(Self::Unspecified),
+            "aws_us_east_1" => Ok(Self::AwsUsEast1),
+            _ => Err("invalid basin scope value".into()),
+        }
+    }
+}
+
+impl From<BasinScope> for i32 {
+    fn from(value: BasinScope) -> Self {
+        api::BasinScope::from(value).into()
+    }
+}
+
+impl TryFrom<i32> for BasinScope {
+    type Error = ConvertError;
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        api::BasinScope::try_from(value)
+            .map(Into::into)
+            .map_err(|_| "invalid basin scope value".into())
+    }
+}
+
+#[sync_docs]
 #[derive(Debug, Clone)]
 pub struct CreateBasinRequest {
     pub basin: BasinName,
     pub config: Option<BasinConfig>,
-    // TODO: Add assignment (when it's supported).
+    pub scope: BasinScope,
 }
 
 impl CreateBasinRequest {
@@ -72,6 +124,7 @@ impl CreateBasinRequest {
         Self {
             basin,
             config: None,
+            scope: BasinScope::Unspecified,
         }
     }
 
@@ -82,15 +135,24 @@ impl CreateBasinRequest {
             ..self
         }
     }
+
+    /// Overwrite basin scope.
+    pub fn with_scope(self, scope: BasinScope) -> Self {
+        Self { scope, ..self }
+    }
 }
 
 impl From<CreateBasinRequest> for api::CreateBasinRequest {
     fn from(value: CreateBasinRequest) -> Self {
-        let CreateBasinRequest { basin, config } = value;
+        let CreateBasinRequest {
+            basin,
+            config,
+            scope,
+        } = value;
         Self {
             basin: basin.0,
             config: config.map(Into::into),
-            assignment: None,
+            scope: scope.into(),
         }
     }
 }
@@ -99,15 +161,18 @@ impl From<CreateBasinRequest> for api::CreateBasinRequest {
 #[derive(Debug, Clone, Default)]
 pub struct BasinConfig {
     pub default_stream_config: Option<StreamConfig>,
+    pub create_stream_on_append: bool,
 }
 
 impl From<BasinConfig> for api::BasinConfig {
     fn from(value: BasinConfig) -> Self {
         let BasinConfig {
             default_stream_config,
+            create_stream_on_append,
         } = value;
         Self {
             default_stream_config: default_stream_config.map(Into::into),
+            create_stream_on_append,
         }
     }
 }
@@ -117,9 +182,11 @@ impl TryFrom<api::BasinConfig> for BasinConfig {
     fn try_from(value: api::BasinConfig) -> Result<Self, Self::Error> {
         let api::BasinConfig {
             default_stream_config,
+            create_stream_on_append,
         } = value;
         Ok(Self {
             default_stream_config: default_stream_config.map(TryInto::try_into).transpose()?,
+            create_stream_on_append,
         })
     }
 }
@@ -320,23 +387,16 @@ impl std::fmt::Display for BasinState {
 #[derive(Debug, Clone)]
 pub struct BasinInfo {
     pub name: String,
-    pub scope: String,
-    pub cell: String,
+    pub scope: BasinScope,
     pub state: BasinState,
 }
 
 impl From<BasinInfo> for api::BasinInfo {
     fn from(value: BasinInfo) -> Self {
-        let BasinInfo {
-            name,
-            scope,
-            cell,
-            state,
-        } = value;
+        let BasinInfo { name, scope, state } = value;
         Self {
             name,
-            scope,
-            cell,
+            scope: scope.into(),
             state: state.into(),
         }
     }
@@ -345,16 +405,10 @@ impl From<BasinInfo> for api::BasinInfo {
 impl TryFrom<api::BasinInfo> for BasinInfo {
     type Error = ConvertError;
     fn try_from(value: api::BasinInfo) -> Result<Self, Self::Error> {
-        let api::BasinInfo {
-            name,
-            scope,
-            cell,
-            state,
-        } = value;
+        let api::BasinInfo { name, scope, state } = value;
         Ok(Self {
             name,
-            scope,
-            cell,
+            scope: scope.try_into()?,
             state: state.try_into()?,
         })
     }
@@ -1539,6 +1593,7 @@ impl TryFrom<api::ReadResponse> for ReadOutput {
 pub struct ReadSessionRequest {
     pub start_seq_num: u64,
     pub limit: ReadLimit,
+    pub heartbeats: bool,
 }
 
 impl ReadSessionRequest {
@@ -1555,10 +1610,16 @@ impl ReadSessionRequest {
         Self { limit, ..self }
     }
 
+    /// Overwrite heartbeats.
+    pub fn with_heartbeats(self, heartbeats: bool) -> Self {
+        Self { heartbeats, ..self }
+    }
+
     pub(crate) fn into_api_type(self, stream: impl Into<String>) -> api::ReadSessionRequest {
         let Self {
             start_seq_num,
             limit,
+            heartbeats,
         } = self;
         api::ReadSessionRequest {
             stream: stream.into(),
@@ -1567,6 +1628,7 @@ impl ReadSessionRequest {
                 count: limit.count,
                 bytes: limit.bytes,
             }),
+            heartbeats,
         }
     }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Upgrade proto definitions and update basin and stream configurations in the Rust SDK for S2.
> 
>   - **Proto Upgrade**:
>     - Update proto submodule commit in `proto`.
>     - Change Rust edition in `Cargo.toml` from 2021 to 2024.
>   - **Basin Configuration**:
>     - Add `create_stream_on_append` to `BasinConfig` in `src/api.rs` and `src/types.rs`.
>     - Modify `CreateBasinRequest` to use `BasinScope` enum in `src/api.rs` and `src/types.rs`.
>   - **Stream Management**:
>     - Add `heartbeats` field to `ReadSessionRequest` in `src/api.rs`.
>     - Update `ReadSessionResponse` to handle heartbeat messages in `src/api.rs`.
>   - **Examples**:
>     - Update `create_basin.rs` and `reconfigure_basin.rs` to use new `BasinConfig` fields.
>   - **Miscellaneous**:
>     - Minor import reordering in `src/append_session.rs` and `src/client.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=s2-streamstore%2Fs2-sdk-rust&utm_source=github&utm_medium=referral)<sup> for 46de446970b666424f2179790a2e4cef23ebc2d5. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->