### PR TITLE
chore(release): 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.10.0] - 2025-03-19
+
+### Features
+
+- [**breaking**] Timestamped records  ([#157](https://github.com/s2-streamstore/s2-sdk-rust/issues/157))
+
 ## [0.9.0] - 2025-03-12
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "streamstore"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-stream",
  "backon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "streamstore"
 description = "Rust SDK for S2"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 license = "Apache-2.0"
 keywords = ["wal", "grpc", "s2", "log", "stream"]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump `streamstore` version to 0.10.0 with breaking change for timestamped records.
> 
>   - **Version Bump**:
>     - Update `streamstore` version from `0.9.0` to `0.10.0` in `Cargo.toml` and `Cargo.lock`.
>   - **Changelog**:
>     - Add entry for version `0.10.0` in `CHANGELOG.md` with a breaking change for timestamped records.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=s2-streamstore%2Fs2-sdk-rust&utm_source=github&utm_medium=referral)<sup> for 08cc5c661da9a15537acda05747bfd7fee767ee4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->