### PR TITLE
feat: `until` timestamp in reads + new metrics op types

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -454,6 +454,11 @@ pub struct ReadRequest {
     /// which is up to 1000 records or 1MiB of metered bytes.
     #[prost(message, optional, tag = "3")]
     pub limit: ::core::option::Option<ReadLimit>,
+    /// Exclusive timestamp to read until.
+    /// If provided, this is applied as an additional constraint on top of the `limit`,
+    /// and will guarantee that all records returned have timestamps < the provided `until`.
+    #[prost(uint64, optional, tag = "6")]
+    pub until: ::core::option::Option<u64>,
     /// Starting position for records.
     /// Retrieved batches will start at the first record whose position is greater than or equal to it.
     #[prost(oneof = "read_request::Start", tags = "2, 4, 5")]
@@ -511,6 +516,11 @@ pub struct ReadSessionRequest {
     /// as well as when no records are available at a randomized interval between 5 and 15 seconds.
     #[prost(bool, tag = "4")]
     pub heartbeats: bool,
+    /// Exclusive timestamp to read until.
+    /// If provided, this is applied as an additional constraint on top of the `limit`,
+    /// and will guarantee that all records returned have timestamps < the provided `until`.
+    #[prost(uint64, optional, tag = "7")]
+    pub until: ::core::option::Option<u64>,
     /// Starting position for records.
     /// Retrieved batches will start at the first record whose position is greater than or equal to it.
     #[prost(oneof = "read_session_request::Start", tags = "2, 5, 6")]
@@ -724,6 +734,12 @@ pub enum Operation {
     Trim = 17,
     /// Set a fencing token for a stream.
     Fence = 18,
+    /// Retrieve account-level metrics.
+    AccountMetrics = 19,
+    /// Retrieve basin-level metrics.
+    BasinMetrics = 20,
+    /// Retrieve stream-level metrics.
+    StreamMetrics = 21,
 }
 impl Operation {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -751,6 +767,9 @@ impl Operation {
             Self::Read => "OPERATION_READ",
             Self::Trim => "OPERATION_TRIM",
             Self::Fence => "OPERATION_FENCE",
+            Self::AccountMetrics => "OPERATION_ACCOUNT_METRICS",
+            Self::BasinMetrics => "OPERATION_BASIN_METRICS",
+            Self::StreamMetrics => "OPERATION_STREAM_METRICS",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -775,6 +794,9 @@ impl Operation {
             "OPERATION_READ" => Some(Self::Read),
             "OPERATION_TRIM" => Some(Self::Trim),
             "OPERATION_FENCE" => Some(Self::Fence),
+            "OPERATION_ACCOUNT_METRICS" => Some(Self::AccountMetrics),
+            "OPERATION_BASIN_METRICS" => Some(Self::BasinMetrics),
+            "OPERATION_STREAM_METRICS" => Some(Self::StreamMetrics),
             _ => None,
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,7 @@
 //! Types for interacting with S2 services.
 
 use std::{collections::HashSet, ops::Deref, str::FromStr, sync::OnceLock, time::Duration};
-
+use std::ops::RangeTo;
 use bytes::Bytes;
 use rand::Rng;
 use regex::Regex;
@@ -1628,6 +1628,7 @@ impl From<ReadStart> for api::read_session_request::Start {
 pub struct ReadRequest {
     pub start: ReadStart,
     pub limit: ReadLimit,
+    pub until: Option<RangeTo<u64>>
 }
 
 impl ReadRequest {
@@ -1643,6 +1644,11 @@ impl ReadRequest {
     pub fn with_limit(self, limit: ReadLimit) -> Self {
         Self { limit, ..self }
     }
+
+    /// Provide an `until` timestamp.
+    pub fn with_until(self, until: RangeTo<u64>) -> Self {
+        Self { until: Some(until), ..self}
+    }
 }
 
 impl ReadRequest {
@@ -1650,7 +1656,7 @@ impl ReadRequest {
         self,
         stream: impl Into<String>,
     ) -> Result<api::ReadRequest, ConvertError> {
-        let Self { start, limit } = self;
+        let Self { start, limit, until } = self;
 
         let limit = if limit.count > Some(1000) {
             Err("read limit: count must not exceed 1000 for unary request")
@@ -1667,6 +1673,7 @@ impl ReadRequest {
             stream: stream.into(),
             start: Some(start.into()),
             limit: Some(limit),
+            until: until.map(|range| range.end) ,
         })
     }
 }
@@ -1793,6 +1800,7 @@ impl TryFrom<api::ReadResponse> for ReadOutput {
 pub struct ReadSessionRequest {
     pub start: ReadStart,
     pub limit: ReadLimit,
+    pub until: Option<RangeTo<u64>>
 }
 
 impl ReadSessionRequest {
@@ -1809,8 +1817,13 @@ impl ReadSessionRequest {
         Self { limit, ..self }
     }
 
+    /// Provide an `until` timestamp.
+    pub fn with_until(self, until: RangeTo<u64>) -> Self {
+        Self { until: Some(until), ..self}
+    }
+
     pub(crate) fn into_api_type(self, stream: impl Into<String>) -> api::ReadSessionRequest {
-        let Self { start, limit } = self;
+        let Self { start, limit, until } = self;
         api::ReadSessionRequest {
             stream: stream.into(),
             start: Some(start.into()),
@@ -1819,6 +1832,7 @@ impl ReadSessionRequest {
                 bytes: limit.bytes,
             }),
             heartbeats: false,
+            until: until.map(|range| range.end) ,
         }
     }
 }
@@ -2051,6 +2065,9 @@ pub enum Operation {
     Read,
     Trim,
     Fence,
+    AccountMetrics,
+    BasinMetrics,
+    StreamMetrics
 }
 
 impl FromStr for Operation {
@@ -2076,6 +2093,9 @@ impl FromStr for Operation {
             "read" => Ok(Self::Read),
             "trim" => Ok(Self::Trim),
             "fence" => Ok(Self::Fence),
+            "account-metrics" => Ok(Self::AccountMetrics),
+            "basin-metrics" => Ok(Self::BasinMetrics),
+            "stream-metrics" => Ok(Self::StreamMetrics),
             _ => Err("invalid operation".into()),
         }
     }
@@ -2102,6 +2122,9 @@ impl From<Operation> for api::Operation {
             Operation::Read => Self::Read,
             Operation::Trim => Self::Trim,
             Operation::Fence => Self::Fence,
+            Operation::AccountMetrics => Self::AccountMetrics,
+            Operation::BasinMetrics => Self::BasinMetrics,
+            Operation::StreamMetrics => Self::StreamMetrics,
         }
     }
 }
@@ -2128,6 +2151,9 @@ impl From<api::Operation> for Option<Operation> {
             api::Operation::Read => Some(Operation::Read),
             api::Operation::Trim => Some(Operation::Trim),
             api::Operation::Fence => Some(Operation::Fence),
+            api::Operation::AccountMetrics => Some(Operation::AccountMetrics),
+            api::Operation::BasinMetrics => Some(Operation::BasinMetrics),
+            api::Operation::StreamMetrics => Some(Operation::StreamMetrics),
         }
     }
 }


### PR DESCRIPTION
Adds support for some recent changes to the grpc API.