### PR TITLE
fix: append session assertion failure

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -460,6 +460,7 @@ pub struct ReadRequest {
     #[prost(uint64, optional, tag = "6")]
     pub until: ::core::option::Option<u64>,
     /// Clamp the start position at the tail position.
+    /// If set, the read will start at the tail of the stream if the requested position is greater than it.
     #[prost(bool, tag = "7")]
     pub clamp: bool,
     /// Starting position for records.
@@ -598,7 +599,8 @@ pub mod stream_config {
     #[derive(Clone, Copy, PartialEq, ::prost::Oneof)]
     pub enum RetentionPolicy {
         /// Age in seconds for automatic trimming of records older than this threshold.
-        /// If set to 0, the stream will have infinite retention.
+        /// If this is set to 0, the stream will have infinite retention.
+        /// (While S2 is in public preview, this is capped at 28 days. Let us know if you'd like the cap removed.)
         #[prost(uint64, tag = "2")]
         Age(u64),
     }

--- a/src/append_session.rs
+++ b/src/append_session.rs
@@ -261,7 +261,7 @@ where
     let mut client_input_terminated = false;
     let mut stashed_ack = None;
 
-    while !(client_input_terminated && inflight.is_empty()) {
+    while !(client_input_terminated && inflight.is_empty() && stashed_ack.is_none() && stashed_request.is_none()) {
         tokio::select! {
             (event_ord, _deadline) = &mut timer, if timer.is_armed() => {
                 match TimerEvent::from(event_ord) {


### PR DESCRIPTION
Discovered a path to assertion failure, in the `append_sequence` main tokio::select! loop, via a DST run.

The problem sequence of events:
- Enter the [append loop](https://github.com/s2-streamstore/s2-sdk-rust/blob/main/src/append_session.rs#L264) -- no requests are inflight yet, and the input is not terminated (or detected to be so)
- Within the select, we enter the `next_ack` branch, and receive an `Err` response due to a connection failure; i.e, this does not correspond to a transmitted append (as none have been attempted yet)
- The Err does not cause the loop to exit yet -- it is stashed as a `Result<_>` for later processing (handled the call to ack_and_pop)
- Next loop iter, and we enter the `next_request` block
- `next_request` is None, so we set `client_input_terminated = true`
- The loop is exited
- We hit this [assertion failure](https://github.com/s2-streamstore/s2-sdk-rust/blob/main/src/append_session.rs#L337), since we never processed the stashed ack (the Err from the frontend) before stopping the loop

To fix, we should not exit the main select loop whenever there is a stashed message, as it also represents tractable work remaining (similar to the client input being open, or inflight batches existing).

(This PR also bumps the proto submodule)