### PR TITLE
chore: automate releases with release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,29 @@
+name: release-plz
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  release-plz:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,27 @@
+name: release-tag
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  release-tag:
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run release-plz release
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,22 @@
+# Releasing
+
+Releases are automated via [release-plz](https://release-plz.dev/).
+
+## How it works
+
+1. Push commits to `main` using [conventional commits](https://www.conventionalcommits.org/)
+   - `feat:` → minor version bump
+   - `fix:` → patch version bump
+   - `feat!:` or `BREAKING CHANGE:` → major version bump
+
+2. release-plz automatically creates/updates a release PR with:
+   - Version bump in Cargo.toml
+   - Updated CHANGELOG.md
+
+3. When you merge the release PR:
+   - release-plz creates a git tag
+   - The tag triggers the release workflow (publish to crates.io, create GitHub release)
+
+## Manual override
+
+To force a specific version, edit `Cargo.toml` manually in the release PR before merging.

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,7 @@
+[workspace]
+changelog_config = "cliff.toml"
+publish = false
+git_tag_enable = true
+git_tag_name = "{{ version }}"
+git_release_enable = false
+pr_labels = ["release"]


### PR DESCRIPTION
On push to main, release-plz creates/updates a release PR. When merged, it tags the release triggering the existing CI.