### PR TITLE
fix: explicitly enable git tagging and releases in release-plz

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,4 +1,6 @@
 [workspace]
 changelog_config = "cliff.toml"
+git_tag_enable = true
 git_tag_name = "{{ version }}"
+git_release_enable = true
 pr_labels = ["release"]


### PR DESCRIPTION
## Summary
- Add `git_tag_enable = true` to ensure release-plz creates tags
- Add `git_release_enable = true` to ensure GitHub releases are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)