### PR TITLE
fix: rename S2_INSECURE to S2_SSL_NO_VERIFY

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -167,7 +167,7 @@ pub fn s2_config(compression: Compression) -> Result<S2Config, ValidationError> 
     if std::env::var("S2_ACCOUNT_ENDPOINT").is_ok() && std::env::var("S2_BASIN_ENDPOINT").is_ok() {
         config = config.with_endpoints(S2Endpoints::from_env()?)
     }
-    if std::env::var("S2_INSECURE").is_ok() {
+    if std::env::var("S2_SSL_NO_VERIFY").is_ok() {
         config = config.with_insecure_skip_cert_verification(true);
     }
     config = config.with_compression(compression);


### PR DESCRIPTION
... for the env var to disable SSL verification during tests.

Renamed to match https://github.com/s2-streamstore/s2-cli/pull/210